### PR TITLE
Pushing updates for bitnami repository changes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,8 +26,7 @@ tasks:
     status:
       - helm repo list | grep "bitnami"
     cmds:
-      - helm repo add bitnami https://charts.bitnami.com/bitnami
-      - helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+      - helm repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
 
   test:
     desc: Run automated tests

--- a/charts/commondata-backend/Chart.yaml
+++ b/charts/commondata-backend/Chart.yaml
@@ -23,5 +23,5 @@ appVersion: 1.16.0
 dependencies:
   - name: postgresql
     version: 10.14.4
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled

--- a/charts/sage-backend/Chart.yaml
+++ b/charts/sage-backend/Chart.yaml
@@ -23,5 +23,5 @@ appVersion: 1.16.1
 dependencies:
   - name: postgresql
     version: 10.14.4
-    repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -3,11 +3,11 @@ appVersion: "1.0"
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 10.14.4
 - name: redis
   version: 17.3.17
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   condition: redis.enabled
 description: Apache Superset is a modern, enterprise-ready business intelligence web
   application


### PR DESCRIPTION
## what
* Updated to use proper bitnami repos that have all repo versions for dependencies

## why
* Because Bitnami is a pain when dealing with older dependencies and we are not updating postgresql versions just yet for these


